### PR TITLE
Fix spawnfunc-related issues

### DIFF
--- a/lua/entities/gmod_train_spawner_ext/cl_init.lua
+++ b/lua/entities/gmod_train_spawner_ext/cl_init.lua
@@ -117,12 +117,13 @@ local function getEntityTypes()
 	end
 end
 
+local optionsPanelsRegistry = {}
 local optionsRegistry = {}
 local isAllDraw = false
 
 local function updateListSettingsDecorator(name, callback)
 	return function(self, index, value, data)
-		if isAllDraw and callback then callback(self, optionsRegistry) end
+		if isAllDraw and callback then callback(self, optionsPanelsRegistry) end
 		currentSettings.options[name] = data
 	end
 end
@@ -156,7 +157,7 @@ end
 
 local function updateSliderSettingsDecorator(name, callback)
 	return function(self, value)
-		if isAllDraw and callback then callback(self, optionsRegistry) end
+		if isAllDraw and callback then callback(self, optionsPanelsRegistry) end
 		currentSettings.options[name] = value
 	end
 end
@@ -193,8 +194,6 @@ local function aggregateBySection(spawner)
 end
 
 local function drawOptions(options)
-	isAllDraw = false
-	optionsRegistry = {}
 	if not options then
 		-- TODO: why?
 		return
@@ -207,7 +206,7 @@ local function drawOptions(options)
 			-- without this Metrostroi Advanced would break everything
 			panelRegistry.spawnMode:Clear()
 			-- just in case
-			optionsRegistry.SpawnMode = panelRegistry.spawnMode
+			optionsPanelsRegistry.SpawnMode = panelRegistry.spawnMode
 			for i, value in pairs(option.Elements) do
 				panelRegistry.spawnMode:AddChoice(value, i)
 			end
@@ -229,26 +228,8 @@ local function drawOptions(options)
 
 		local panel = createFunction(option)
 		if not panel then continue end
-		optionsRegistry[option.Name] = panel
-	end
-
-	-- Some trains rely on this (e.g. Ezh3 RU1)
-	optionsRegistry.WagNum = panelRegistry.wagonCount
-
-	isAllDraw = true
-	-- Second pass: create and call all of callbacks, select values and of that shit
-	for _, option in pairs(options) do
-		-- FIXME: empty options? HOW???
-		if not option.Name then continue end
-		if option.Name == "SpawnMode" then continue end
-		setting = optionsRegistry[option.Name]
-		if not setting then continue end
-		if options.ChangeCallback then
-			options.ChangeCallback(setting, optionsRegistry)
-		end
-		-- FIXME: Dynamically created options (e.g. Attach508t on RU1) are not saving their value
-		-- Possibly because they populate their list after that invocation below
-		setting:SetValue(currentSettings.options[option.Name] or option.Default or setting.FirstId or 1)
+		optionsPanelsRegistry[option.Name] = panel
+		optionsRegistry[option.Name] = option
 	end
 end
 
@@ -276,6 +257,10 @@ local function drawSubsections(subsections)
 end
 
 local function drawSections(sections)
+	isAllDraw = false
+	optionsPanelsRegistry = {}
+	optionsRegistry = {}
+
 	-- draw Default section first without section label
 	drawSubsections(sections.Default)
 	sections.Default = nil
@@ -291,6 +276,24 @@ local function drawSections(sections)
 		sectionLabel:SetFont("Arial30Bold")
 		sectionLabel:Dock(BOTTOM)
 		drawSubsections(subsections)
+	end
+
+	-- Some trains rely on this (e.g. Ezh3 RU1)
+	optionsPanelsRegistry.WagNum = panelRegistry.wagonCount
+
+	isAllDraw = true
+	-- Second pass: create and call all of callbacks, select values and of that shit
+	for name, setting in pairs(optionsPanelsRegistry) do
+		if name == "SpawnMode" or name == "WagNum" then continue end
+		local option = optionsRegistry[name]
+		if not setting or not option then continue end
+
+		if option.ChangeCallback then
+			option.ChangeCallback(setting.ComboBox or setting.Slider or setting.CheckBox, optionsPanelsRegistry)
+		end
+		-- FIXME: Dynamically created options (e.g. Attach508t on RU1) are not saving their value
+		-- Possibly because they populate their list after that invocation below
+		setting:SetValue(currentSettings.options[name] or option.Default or setting.FirstId or 1)
 	end
 end
 
@@ -364,7 +367,9 @@ local function drawSidebar(frame)
 	end
 
 	function panelRegistry.wagonCount:OnValueChanged(value)
-		panelRegistry.rootFrame:SetCookie("wagonCount", math.Round(value, 0))
+		value = math.Round(value, 0)
+		panelRegistry.rootFrame:SetCookie("wagonCount", value)
+		self:SetValue(value)
 	end
 
 	-- PANEL Spawn mode chooser

--- a/lua/entities/gmod_train_spawner_ext/elements/list_option.lua
+++ b/lua/entities/gmod_train_spawner_ext/elements/list_option.lua
@@ -23,6 +23,11 @@ function PANEL:SetValue(data)
 	-- Set and select default value
 	if self.OptionByData[data] then
 		self.ComboBox:ChooseOptionID(self.OptionByData[data])
+	else
+		-- Some trains dynamically change the list contents
+		-- This often depends on skin registry, or wagon count (Ezh3 RU1 with older wagons coupled)
+		-- So we want to set something here, if the saved option was not found
+		self.ComboBox:ChooseOptionID(1)
 	end
 end
 

--- a/lua/weapons/gmod_tool/stools/train_spawner_ext.lua
+++ b/lua/weapons/gmod_tool/stools/train_spawner_ext.lua
@@ -197,6 +197,15 @@ function TOOL:SpawnWagon(trace)
         FIXFIXFIX[i]:Spawn()
     end
 
+    -- Many trains (mostly E-derived types) don't know about 'options' field, they expect all settings in-place
+    -- We also leave 'options' field in new table for possible 'forward'-compatibility
+    local settingsFlatten = table.Copy(self.Settings)
+    for k, v in pairs(self.Settings.options) do
+        if not settingsFlatten[k] then
+            settingsFlatten[k] = v
+        end
+    end
+
     local LastRot, LastEnt = false
     local trains = {}
     for i = 1, self.Settings.wagonCount do
@@ -204,7 +213,7 @@ function TOOL:SpawnWagon(trace)
         local ent
         if i == 1 then
             if spawnfunc then
-                ent = self.Train:SpawnFunction(ply, trace, spawnfunc(i, self.Settings, self.Train), self:GetOwner():GetNW2Bool("metrostroi_train_spawner_rev"), UpdateWagPos)
+                ent = self.Train:SpawnFunction(ply, trace, spawnfunc(i, settingsFlatten, self.Train), self:GetOwner():GetNW2Bool("metrostroi_train_spawner_rev"), UpdateWagPos)
             else
                 ent = self.Train:SpawnFunction(ply, trace, self.Train.Spawner.head or self.Train.ClassName, self:GetOwner():GetNW2Bool("metrostroi_train_spawner_rev"), UpdateWagPos)
             end
@@ -225,7 +234,7 @@ function TOOL:SpawnWagon(trace)
         if i > 1 then
             local rot = i == self.Settings.wagonCount or math.random() > 0.5 -- Rotate last wagon or rotate it randomly
             if spawnfunc then
-                ent = ents.Create(spawnfunc(i, self.Settings, self.Train))
+                ent = ents.Create(spawnfunc(i, settingsFlatten, self.Train))
             else
                 ent = ents.Create(i ~= self.Settings.wagonCount and self.Train.Spawner.interim or self.Train.Spawner.head or self.Train.ClassName)
             end


### PR DESCRIPTION
Фиксит данную ошибку на Еж3 РУ1:
`[81-710 Еж3 РУ1 (Ezh3 RU1 for Metrostroi Subway Simulator)] lua/entities/gmod_subway_ezh3ru1/shared.lua:728: attempt to perform arithmetic on field 'Attach508t' (a nil value)`
Также схожие проблемы на других Е-образных.

Также пустые списки не будут отображаться
>  "Схема в салоне" что?

Лично у меня из мешающих игре проблем осталось только то, что чекбоксы не запоминаются. Других проблем не заметил. Использую метрострой с гитхаба.